### PR TITLE
Clarify date the series begins in CFP

### DIFF
--- a/content/cfp.md
+++ b/content/cfp.md
@@ -12,6 +12,10 @@ The PyMCon Web Series consists of events proposed and co-led by members of the P
 ## Key Dates
 Submission deadline: November 30, 2022.
 
+Series begins: after January 1, 2023.
+
+Scheduling of individual events will be coordinated between the contributor and PyMCon Web Series Event leads and are anticipated to occur monthly (appoximately).
+
 ## How to Submit
 Please fill out the submission form available [here](https://forms.gle/GWdiUAPtKsr5mMm99).
 


### PR DESCRIPTION
Trying to clarify confusion reflected in Adrian's comments on slack:

> Somehow I can't find a date for the conference on the website...
> Am I just missing that?

> And a rough timeframe might also be useful, so that if I submit something I have an idea of when I need to be ready :slightly_smiling_face:

> I think this isn't entirely obvious from the website though, at least if you don't read all that closely.
> Maybe it would help to mention that in the "Key Dates" section, just to make it easy for someone who is looking for a date?